### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
 - PUPPET_VERSION=2.7.23
-- PUPPET_VERSION=3.2.4
+- PUPPET_VERSION=3.3.2
 notifications:
 email: false
 rvm:

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,17 @@ require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-   Dir['manifests/**/*.pp'].each do |path|
-     sh "puppet parser validate --noop #{path}"
-   end
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,7 +2,11 @@ require 'spec_helper'
 
 describe 'selinux' do
 
+  it { should compile.with_all_deps }
+
   describe 'has correct selinux_config file attributes' do
+
+    it { should contain_class('selinux') }
 
     it {
       should contain_file('selinux_config').with({
@@ -15,6 +19,9 @@ describe 'selinux' do
   end
 
   describe 'when using default values' do
+
+    it { should contain_class('selinux') }
+
     it {
       should contain_file('selinux_config').with({
         'path' => '/etc/selinux/config',
@@ -29,6 +36,8 @@ describe 'selinux' do
       { :mode => 'enforcing' }
     end
 
+    it { should contain_class('selinux') }
+
     it {
       should contain_file('selinux_config').with_content(/^\s*SELINUX=enforcing$/)
     }
@@ -39,6 +48,8 @@ describe 'selinux' do
       { :mode => 'permissive' }
     end
 
+    it { should contain_class('selinux') }
+
     it {
       should contain_file('selinux_config').with_content(/^\s*SELINUX=permissive$/)
     }
@@ -48,6 +59,8 @@ describe 'selinux' do
     let :params do
       { :mode => 'disabled' }
     end
+
+    it { should contain_class('selinux') }
 
     it {
       should contain_file('selinux_config').with_content(/^\s*SELINUX=disabled$/)
@@ -71,6 +84,8 @@ describe 'selinux' do
       { :type => 'strict' }
     end
 
+    it { should contain_class('selinux') }
+
     it {
       should contain_file('selinux_config').with_content(/^\s*SELINUXTYPE=strict$/)
     }
@@ -80,6 +95,8 @@ describe 'selinux' do
     let :params do
       { :type => 'targeted' }
     end
+
+    it { should contain_class('selinux') }
 
     it {
       should contain_file('selinux_config').with_content(/^\s*SELINUXTYPE=targeted$/)
@@ -105,6 +122,9 @@ describe 'selinux' do
         :type => 'strict'
       }
     end
+
+    it { should contain_class('selinux') }
+
     it {
       should contain_file('selinux_config').with_content(/^\s*SELINUX=enforcing$/)
       should contain_file('selinux_config').with_content(/^\s*SELINUXTYPE=strict$/)
@@ -115,6 +135,8 @@ describe 'selinux' do
     let :params do
       { :config_file => '/etc/selinux.conf' }
     end
+
+    it { should contain_class('selinux') }
 
     it {
       should contain_file('selinux_config').with({


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
