### PR TITLE
Add policytools parameter to provide semanage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ The path to the selinux configuration path to manage.
 
 - *Default*: '/etc/selinux/config'
 
+---
+#### policytools
+If true, manage the `policycoreutils-python` package.  The purpose of this
+behavior is to provide the `semanage` command, e.g. to reconfigure the selinux
+policy such that `restorecon` will restore a file to the desired state.  For
+example, to enable SSH key based login for an user account outside of the normal
+location:
+
+    semanage fcontext -a -t ssh_home_t /var/lib/git/.ssh
+    semanage fcontext -a -t ssh_home_t /var/lib/git/.ssh/authorized_keys
+    restorecon -v /var/lib/git/.ssh/
+    restorecon -v /var/lib/git/.ssh/authorized_keys
+
+- *Default*: false
+
+=======
+
 ### Examples
 
 To enable SELinux

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class selinux (
   Pattern[/^targeted|strict$/]                $type         = 'targeted',
   Variant[Undef, Enum['0','1'], Integer[0,1]] $setlocaldefs = undef,
   Stdlib::Absolutepath                        $config_file  = '/etc/selinux/config',
+  Boolean                                     $policytools  = false,
 ) {
 
   # selinux allows you to set the system to permissive or enforcing while
@@ -54,5 +55,14 @@ class selinux (
     group   => 'root',
     mode    => '0644',
     content => template('selinux/config.erb'),
+  }
+
+  # Provide the semanage command to allow permanent configuration of the selinux
+  # policy.  This allows the restorecon command to restore policy to a specified
+  # default.
+  if $policytools == true {
+    package { 'policycoreutils-python':
+      ensure => installed,
+    }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -138,4 +138,27 @@ describe 'selinux' do
       }
     end
   end
+
+  describe 'policytools class parameter' do
+    context 'when false' do
+      let(:params) { { :policytools => false } }
+      it 'includes the selinux class' do
+        expect(subject).to contain_class('selinux')
+      end
+      it 'does not manage package { "policycoreutils-python": }' do
+        expect(subject).not_to contain_package('policycoreutils-python')
+      end
+    end
+    context 'when true' do
+      let(:params) { { :policytools => true } }
+      it 'includes the selinux class' do
+        expect(subject).to contain_class('selinux')
+      end
+      it 'manages package { "policycoreutils-python": }' do
+        expect(subject).to contain_package('policycoreutils-python').with({
+          'ensure' => 'installed',
+        })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Without this patch, the selinux module doesn't manage the
`policycoreutils-python` package which is necessary to provide the `semanage`
command.  This command is necessary to update the selinux policy itself so that
`restorecon` is able to restore the context of a file to a desired state.
